### PR TITLE
fix: logic for gulch west ledge item

### DIFF
--- a/src/js/stores/logic.js
+++ b/src/js/stores/logic.js
@@ -7623,7 +7623,7 @@ export const useLogicStore = defineStore('logic', () => {
 								return true;
 							},
 							available: () => {
-								return flags.gusty_gulch() && (flags.partner('kooper') || flags.partner('parakarry'));
+								return flags.gusty_gulch() && flags.partner('kooper');
 							},
 							ap: [8112000406]
 						},


### PR DESCRIPTION
Reaching this item with Parakarry is a glitch setting and very precise.  

Not recommended for casual play